### PR TITLE
NTP v3.2

### DIFF
--- a/node_settings_generator/types_utils.py
+++ b/node_settings_generator/types_utils.py
@@ -4,16 +4,18 @@ from typing import Dict
 READ_ONLY_TYPES = {
     "ST.BAKE_ITEMS",
     "ST.COLOR_RAMP",
+    "ST.CAPTURE_ATTRIBUTE_ITEMS",
     "ST.CRYPTOMATTE_ENTRIES",
     "ST.CURVE_MAPPING",
     "ST.ENUM_DEFINITION",
     "ST.FILE_SLOTS",
     "ST.IMAGE_FORMAT_SETTINGS",
     "ST.IMAGE_USER",
+    "ST.INDEX_SWITCH_ITEMS",
     "ST.LAYER_SLOTS",
+    "ST.MENU_SWITCH_ITEMS",
     "ST.REPEAT_OUTPUT_ITEMS",
     "ST.SIM_OUTPUT_ITEMS",
-    "ST.INDEX_SWITCH_ITEMS"
 } 
 
 doc_to_NTP_type_dict : Dict[str, str] = {
@@ -39,15 +41,19 @@ doc_to_NTP_type_dict : Dict[str, str] = {
     "Mask" : "ST.MASK",
     "Material" : "ST.MATERIAL",
     "mathutils.Color" : "ST.COLOR",
+    "mathutils.Euler" : "ST.EULER", #TODO
     "mathutils.Vector of 3" : "ST.VEC3",
     "MovieClip" : "ST.MOVIE_CLIP",
     "Node" : None, # (<4.2) Always used with zone inputs, need to make sure 
                    # output nodes exist. Handled separately from NTP attr system
     "NodeEnumDefinition" : "ST.ENUM_DEFINITION",
+    "NodeEnumItem" : "ST.ENUM_ITEM",
     "NodeGeometryBakeItems" : "ST.BAKE_ITEMS",
+    "NodeGeometryCaptureAttributeItems" : "ST.CAPTURE_ATTRIBUTE_ITEMS", #TODO
     "NodeGeometryRepeatOutputItems" : "ST.REPEAT_OUTPUT_ITEMS",
     "NodeGeometrySimulationOutputItems" : "ST.SIM_OUTPUT_ITEMS",
     "NodeIndexSwitchItems" : "ST.INDEX_SWITCH_ITEMS",
+    "NodeMenuSwitchItems" : "ST.MENU_SWITCH_ITEMS", #TODO
     "NodeTree" : "ST.NODE_TREE",
     "Object" : "ST.OBJECT",
     "ParticleSystem" : "ST.PARTICLE_SYSTEM",

--- a/node_settings_generator/types_utils.py
+++ b/node_settings_generator/types_utils.py
@@ -1,71 +1,121 @@
-from typing import Dict
+from enum import Enum, auto
+
+class ST(Enum):
+    """
+    Settings Types
+    """
+    # Primitives
+    BOOL        = auto()
+    COLOR       = auto()
+    ENUM        = auto()
+    ENUM_SET    = auto()
+    FLOAT       = auto()
+    INT         = auto()
+    STRING      = auto()
+    VEC1        = auto()
+    VEC2        = auto()
+    VEC3        = auto()
+    VEC4        = auto()
+    
+    # Special settings
+    BAKE_ITEMS          = auto()
+    COLOR_RAMP          = auto()
+    CURVE_MAPPING       = auto()
+    ENUM_DEFINITION     = auto()
+    INDEX_SWITCH_ITEMS  = auto()
+    NODE_TREE           = auto()
+    REPEAT_OUTPUT_ITEMS = auto()
+    SIM_OUTPUT_ITEMS    = auto()
+
+    # Image
+    IMAGE       = auto() #needs refactor
+    IMAGE_USER  = auto() #needs refactor
+
+    # Currently unimplemented
+    CAPTURE_ATTRIBUTE_ITEMS     = auto() #TODO NTP v3.2
+    CRYPTOMATTE_ENTRIES         = auto()
+    ENUM_ITEM                   = auto() #TODO NTP v3.2
+    EULER                       = auto() #TODO NTP v3.2
+    FILE_SLOTS                  = auto()
+    FONT                        = auto()
+    IMAGE_FORMAT_SETTINGS       = auto()
+    LAYER_SLOTS                 = auto()
+    MASK                        = auto()
+    MATERIAL                    = auto() #TODO asset library
+    MENU_SWITCH_ITEMS           = auto() #TODO NTP v3.2
+    MOVIE_CLIP                  = auto() 
+    OBJECT                      = auto() #TODO asset library
+    PARTICLE_SYSTEM             = auto()
+    SCENE                       = auto()
+    TEXT                        = auto()
+    TEXTURE                     = auto()
 
 #types expected to be marked as read-only
-READ_ONLY_TYPES = {
-    "ST.BAKE_ITEMS",
-    "ST.COLOR_RAMP",
-    "ST.CAPTURE_ATTRIBUTE_ITEMS",
-    "ST.CRYPTOMATTE_ENTRIES",
-    "ST.CURVE_MAPPING",
-    "ST.ENUM_DEFINITION",
-    "ST.FILE_SLOTS",
-    "ST.IMAGE_FORMAT_SETTINGS",
-    "ST.IMAGE_USER",
-    "ST.INDEX_SWITCH_ITEMS",
-    "ST.LAYER_SLOTS",
-    "ST.MENU_SWITCH_ITEMS",
-    "ST.REPEAT_OUTPUT_ITEMS",
-    "ST.SIM_OUTPUT_ITEMS",
+READ_ONLY_TYPES : set[ST] = {
+    ST.BAKE_ITEMS,
+    ST.CAPTURE_ATTRIBUTE_ITEMS,
+    ST.COLOR_RAMP,
+    ST.CRYPTOMATTE_ENTRIES,
+    ST.CURVE_MAPPING,
+    ST.ENUM_DEFINITION,
+    ST.FILE_SLOTS,
+    ST.IMAGE_FORMAT_SETTINGS,
+    ST.IMAGE_USER,
+    ST.INDEX_SWITCH_ITEMS,
+    ST.LAYER_SLOTS,
+    ST.MENU_SWITCH_ITEMS,
+    ST.REPEAT_OUTPUT_ITEMS,
+    ST.SIM_OUTPUT_ITEMS,
 } 
 
-doc_to_NTP_type_dict : Dict[str, str] = {
+doc_to_NTP_type_dict : dict[str, ST] = {
     "" : "",
-    "bpy_prop_collection of CryptomatteEntry": "ST.CRYPTOMATTE_ENTRIES",
-    "boolean" : "ST.BOOL",
+    "bpy_prop_collection of CryptomatteEntry": ST.CRYPTOMATTE_ENTRIES,
+    "boolean" : ST.BOOL,
     "ColorMapping" : None, # Always read-only
-    "ColorRamp" : "ST.COLOR_RAMP",
-    "CompositorNodeOutputFileFileSlots" : "ST.FILE_SLOTS",
-    "CompositorNodeOutputFileLayerSlots" : "ST.LAYER_SLOTS",
-    "CurveMapping" : "ST.CURVE_MAPPING",
-    "enum" : "ST.ENUM",
-    "enum set" : "ST.ENUM_SET",
-    "float" : "ST.FLOAT",
-    "float array of 1" : "ST.VEC1",
-    "float array of 2" : "ST.VEC2",
-    "float array of 3" : "ST.VEC3",
-    "float array of 4" : "ST.VEC4",
-    "Image" : "ST.IMAGE",
-    "ImageFormatSettings" : "ST.IMAGE_FORMAT_SETTINGS",
-    "ImageUser" : "ST.IMAGE_USER",
-    "int" : "ST.INT",
-    "Mask" : "ST.MASK",
-    "Material" : "ST.MATERIAL",
-    "mathutils.Color" : "ST.COLOR",
-    "mathutils.Euler" : "ST.EULER", #TODO
-    "mathutils.Vector of 3" : "ST.VEC3",
-    "MovieClip" : "ST.MOVIE_CLIP",
+    "ColorRamp" : ST.COLOR_RAMP,
+    "CompositorNodeOutputFileFileSlots" : ST.FILE_SLOTS,
+    "CompositorNodeOutputFileLayerSlots" : ST.LAYER_SLOTS,
+    "CurveMapping" : ST.CURVE_MAPPING,
+    "enum" : ST.ENUM,
+    "enum set" : ST.ENUM_SET,
+    "float" : ST.FLOAT,
+    "float array of 1" : ST.VEC1,
+    "float array of 2" : ST.VEC2,
+    "float array of 3" : ST.VEC3,
+    "float array of 4" : ST.VEC4,
+    "Image" : ST.IMAGE,
+    "ImageFormatSettings" : ST.IMAGE_FORMAT_SETTINGS,
+    "ImageUser" : ST.IMAGE_USER,
+    "int" : ST.INT,
+    "Mask" : ST.MASK,
+    "Material" : ST.MATERIAL,
+    "mathutils.Color" : ST.COLOR,
+    "mathutils.Euler" : ST.EULER, #TODO
+    "mathutils.Vector of 3" : ST.VEC3,
+    "MovieClip" : ST.MOVIE_CLIP,
     "Node" : None, # (<4.2) Always used with zone inputs, need to make sure 
                    # output nodes exist. Handled separately from NTP attr system
-    "NodeEnumDefinition" : "ST.ENUM_DEFINITION",
-    "NodeEnumItem" : "ST.ENUM_ITEM",
-    "NodeGeometryBakeItems" : "ST.BAKE_ITEMS",
-    "NodeGeometryCaptureAttributeItems" : "ST.CAPTURE_ATTRIBUTE_ITEMS", #TODO
-    "NodeGeometryRepeatOutputItems" : "ST.REPEAT_OUTPUT_ITEMS",
-    "NodeGeometrySimulationOutputItems" : "ST.SIM_OUTPUT_ITEMS",
-    "NodeIndexSwitchItems" : "ST.INDEX_SWITCH_ITEMS",
-    "NodeMenuSwitchItems" : "ST.MENU_SWITCH_ITEMS", #TODO
-    "NodeTree" : "ST.NODE_TREE",
-    "Object" : "ST.OBJECT",
-    "ParticleSystem" : "ST.PARTICLE_SYSTEM",
+    "NodeEnumDefinition" : ST.ENUM_DEFINITION,
+    "NodeEnumItem" : ST.ENUM_ITEM,
+    "NodeGeometryBakeItems" : ST.BAKE_ITEMS,
+    "NodeGeometryCaptureAttributeItems" : ST.CAPTURE_ATTRIBUTE_ITEMS,
+    "NodeGeometryRepeatOutputItems" : ST.REPEAT_OUTPUT_ITEMS,
+    "NodeGeometrySimulationOutputItems" : ST.SIM_OUTPUT_ITEMS,
+    "NodeIndexSwitchItems" : ST.INDEX_SWITCH_ITEMS,
+    "NodeMenuSwitchItems" : ST.MENU_SWITCH_ITEMS,
+    "NodeTree" : ST.NODE_TREE,
+    "Object" : ST.OBJECT,
+    "ParticleSystem" : ST.PARTICLE_SYSTEM,
     "PropertyGroup" : None, #Always read-only
     "RepeatItem" : None, #Always set with index
-    "Scene" : "ST.SCENE",
+    "Scene" : ST.SCENE,
     "SimulationStateItem" : None, #Always set with index
-    "string" : "ST.STRING",
+    "string" : ST.STRING,
     "TexMapping" : None, #Always read-only
-    "Text" : "ST.TEXT",
-    "Texture" : "ST.TEXTURE",
-    "VectorFont" : "ST.FONT"
+    "Text" : ST.TEXT,
+    "Texture" : ST.TEXTURE,
+    "VectorFont" : ST.FONT
 }
 
 def get_NTP_type(type_str: str) -> str:


### PR DESCRIPTION
#Features
* #6
* #9 
* #10 
#Fixes
* #8
#Refactor
* `types_utils` now uses `ST` class directly, rather than string representations
